### PR TITLE
&& と || に対応

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -75,6 +75,35 @@ Blockly.Blocks['logic_operator_typed'] = {
   }
 }
 
+Blockly.Blocks['not_operator_typed'] = {
+  /**
+   * Block for "not" operator.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.setColour(210);
+    this.setOutput(true, 'Boolean');
+    this.setOutputTypeExpr(new Blockly.TypeExpr.BOOL());
+    this.appendValueInput('A')
+        .setTypeExpr(new Blockly.TypeExpr.BOOL())
+        .appendField('not');
+    this.setInputsInline(true);
+    this.setTooltip('Logical negation operator.');
+  },
+
+  clearTypes: function() {
+    this.callClearTypes('A');
+  },
+
+  infer: function(ctx) {
+    var expected = new Blockly.TypeExpr.BOOL();
+    var arg = this.callInfer('A', ctx);
+    if (arg)
+      arg.unify(expected);
+    return expected;
+  }
+}
+
 Blockly.Blocks['logic_compare_typed'] = {
   /**
    * Block for comparison operator.

--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -102,7 +102,7 @@ Blockly.Blocks['not_operator_typed'] = {
       arg.unify(expected);
     return expected;
   }
-}
+};
 
 Blockly.Blocks['logic_compare_typed'] = {
   /**

--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -28,6 +28,53 @@ Blockly.Blocks['logic_boolean_typed'] = {
   }
 };
 
+Blockly.Blocks['logic_operator_typed'] = {
+  /**
+   * Block for logical operator.
+   * @this Blockly.Block
+   */
+  init: function() {
+    var OPERATORS =
+        [['&&', 'AND'],
+         ['||', 'OR']];
+    this.setColour(210);
+    this.setOutput(true, 'Boolean');
+    this.setOutputTypeExpr(new Blockly.TypeExpr.BOOL());
+    this.appendValueInput('A')
+        .setTypeExpr(new Blockly.TypeExpr.BOOL());
+    this.appendValueInput('B')
+        .setTypeExpr(new Blockly.TypeExpr.BOOL())
+        .appendField(new Blockly.FieldDropdown(OPERATORS), 'OP_BOOL');
+    this.setInputsInline(true);
+    // Assign 'this' to a variable for use in the tooltip closure below.
+    var thisBlock = this;
+    this.setTooltip(function() {
+      var mode = thisBlock.getFieldValue('OP_BOOL');
+      var TOOLTIPS = {
+        'AND': 'Logical product operator.',
+        'OR': 'Logical sum operator.'
+      };
+      return TOOLTIPS[mode];
+    });
+  },
+
+  clearTypes: function() {
+    this.callClearTypes('A');
+    this.callClearTypes('B');
+  },
+
+  infer: function(ctx) {
+    var expected_left = new Blockly.TypeExpr.BOOL();
+    var left = this.callInfer('A', ctx);
+    var right = this.callInfer('B', ctx);
+    if (left)
+      left.unify(expected_left);
+    if (right)
+      right.unify(expected_left);
+    return expected_left;
+  }
+}
+
 Blockly.Blocks['logic_compare_typed'] = {
   /**
    * Block for comparison operator.

--- a/demos/typed/dev.html
+++ b/demos/typed/dev.html
@@ -40,6 +40,7 @@
   <xml id="toolbox" style="display: none">
     <category name="Logic" colour="%{BKY_LOGIC_HUE}">
       <block type="logic_boolean_typed"></block>
+      <block type="logic_operator_typed"></block>
       <block type="logic_ternary_typed"></block>
       <block type="logic_compare_typed"></block>
     </category>

--- a/demos/typed/dev.html
+++ b/demos/typed/dev.html
@@ -40,6 +40,7 @@
   <xml id="toolbox" style="display: none">
     <category name="Logic" colour="%{BKY_LOGIC_HUE}">
       <block type="logic_boolean_typed"></block>
+      <block type="not_operator_typed"></block>
       <block type="logic_operator_typed"></block>
       <block type="logic_ternary_typed"></block>
       <block type="logic_compare_typed"></block>

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -14,6 +14,14 @@ Blockly.TypedLang['logic_boolean_typed'] = function(block) {
   return [code, Blockly.TypedLang.ORDER_ATOMIC];
 };
 
+Blockly.TypedLang['not_operator_typed'] = function(block) {
+  // Boolean operator "not".
+  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+      Blockly.TypedLang.ORDER_ATOMIC);
+  var code = '(not ' + argument + ')';
+  return [code, Blockly.TypedLang.ORDER_ATOMIC];
+}
+
 Blockly.TypedLang['logic_operator_typed'] = function(block) {
   // Boolean operators && and ||.
   var OPERATORS = {

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -20,7 +20,7 @@ Blockly.TypedLang['not_operator_typed'] = function(block) {
       Blockly.TypedLang.ORDER_ATOMIC);
   var code = '(not ' + argument + ')';
   return [code, Blockly.TypedLang.ORDER_ATOMIC];
-}
+};
 
 Blockly.TypedLang['logic_operator_typed'] = function(block) {
   // Boolean operators && and ||.
@@ -35,7 +35,7 @@ Blockly.TypedLang['logic_operator_typed'] = function(block) {
       Blockly.TypedLang.ORDER_ATOMIC);
   var code = '(' + argument0 + operator + argument1 + ')';
   return [code, Blockly.TypedLang.ORDER_ATOMIC];
-}
+};
 
 Blockly.TypedLang['logic_compare_typed'] = function(block) {
   // Comparison operator.

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -14,6 +14,21 @@ Blockly.TypedLang['logic_boolean_typed'] = function(block) {
   return [code, Blockly.TypedLang.ORDER_ATOMIC];
 };
 
+Blockly.TypedLang['logic_operator_typed'] = function(block) {
+  // Boolean operators && and ||.
+  var OPERATORS = {
+    'AND': ' && ',
+    'OR': ' || '
+  };
+  var operator = OPERATORS[block.getFieldValue('OP_BOOL')];
+  var argument0 = Blockly.TypedLang.valueToCode(block, 'A',
+      Blockly.TypedLang.ORDER_ATOMIC);
+  var argument1 = Blockly.TypedLang.valueToCode(block, 'B',
+      Blockly.TypedLang.ORDER_ATOMIC);
+  var code = '(' + argument0 + operator + argument1 + ')';
+  return [code, Blockly.TypedLang.ORDER_ATOMIC];
+}
+
 Blockly.TypedLang['logic_compare_typed'] = function(block) {
   // Comparison operator.
   var OPERATORS = {


### PR DESCRIPTION
`&&` か `||` を選択する論理演算子ブロックと `not` 演算子ブロックを追加しました。

<img width="1107" alt="2019-02-21 16 54 10" src="https://user-images.githubusercontent.com/32429539/53152648-73f3d800-35f9-11e9-88fd-70fc80f544fb.png">
