### PR TITLE
reintroduce ORDER_NONE, remove ;;, write 'let _ =' for naked values

### DIFF
--- a/generators/typedlang.js
+++ b/generators/typedlang.js
@@ -73,6 +73,7 @@ Blockly.TypedLang.ORDER_WITH = 19;            // with
 Blockly.TypedLang.ORDER_SEMI = 20;            // ;
 Blockly.TypedLang.ORDER_IN = 21;              // in
 Blockly.TypedLang.ORDER_EXPR = 50;            // any expression
+Blockly.TypedLang.ORDER_NONE = 99;            // (...)
 
 /**
  * List of outer-inner pairings that do NOT require parentheses.
@@ -160,7 +161,7 @@ Blockly.TypedLang.finish = function(code) {
  * @return {string} Legal line of code.
  */
 Blockly.TypedLang.scrubNakedValue = function(line) {
-  return line + '\n';
+  return 'let _ = ' + line + '\n';
 };
 
 /**

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -66,8 +66,6 @@ Blockly.TypedLang['logic_ternary_typed'] = function(block) {
       Blockly.TypedLang.ORDER_ELSE) || '?';
   var code = 'if ' + value_if + ' then ' + value_then + ' else ' +
       value_else;
-  // TODO: Make sure that this supports the following case.
-  // `(if e then e else e); e -> if e then e else e; e`
   return [code, Blockly.TypedLang.ORDER_EXPR];
 };
 
@@ -265,14 +263,15 @@ Blockly.TypedLang['let_typed'] = function(block) {
   var varname = block.typedValue['VAR'].getVariableName();
   var arg = args.length == 0 ? '' : ' ' + args.join(' ');
   var exp1 = Blockly.TypedLang.valueToCode(block, 'EXP1',
-      Blockly.TypedLang.ORDER_EXPR) || '?';
+      Blockly.TypedLang.ORDER_NONE) || '?';
+	// ORDER_NONE = no parenthesis needed for exp1
 
   var code = 'let ';
   if (block.isRecursive()) code += 'rec ';
   code += varname + arg + ' = ' + exp1;
 
   if (block.getIsStatement()) {
-    code += ';;\n';
+    code += '\n';
     return code;
   }
   var exp2 = Blockly.TypedLang.valueToCode(block, 'EXP2',


### PR DESCRIPTION
- typedlang.js で ORDER_NONE の定義を捨ててしまっていたのを復活させた。
- typedlang/blocks.js で if 文のところで TODO を書いていたけど、これは逐次実行文を実装した後の話なことに気がついたので、削除した。
- typedlang/blocks.js の let_typed のところで、exp1 にかっこが付かないようにするため ORDER_EXPR を ORDER_NONE にした。
- typedlang.js の scrubNakedValue で、値のブロックがそのままワークスペースにあった場合、そのままコードにするのではなく let _ = というのを前につけるようにした。
- それに伴って、in のない let 文の最後に ;; をつけるのを廃止した。