### PR TITLE
bug fix: 5 - (3 - 1) was printed as 5 - 3 - 1

### DIFF
--- a/generators/typedlang.js
+++ b/generators/typedlang.js
@@ -56,10 +56,10 @@ Blockly.TypedLang.addReservedWords(
  */
 Blockly.TypedLang.ORDER_ATOMIC = 0;           // 0 "" ...
 Blockly.TypedLang.ORDER_FUNCTION_CALL = 2;    // f x
-Blockly.TypedLang.ORDER_MULTIPLICATION = 5;   // * (INFIXOP3)
-Blockly.TypedLang.ORDER_DIVISION = 5;         // / (INFIXOP3)
-Blockly.TypedLang.ORDER_SUBTRACTION = 6;      // - (INFIXOP2)
-Blockly.TypedLang.ORDER_ADDITION = 6;         // + (INFIXOP2)
+Blockly.TypedLang.ORDER_MULTIPLICATION = 5.1; // * (INFIXOP3)
+Blockly.TypedLang.ORDER_DIVISION = 5.2;       // / (INFIXOP3)
+Blockly.TypedLang.ORDER_SUBTRACTION = 6.1;    // - (INFIXOP2)
+Blockly.TypedLang.ORDER_ADDITION = 6.2;       // + (INFIXOP2)
 Blockly.TypedLang.ORDER_CONS = 7;             // ::
 Blockly.TypedLang.ORDER_CONCAT_STRING = 8;    // ^ (INFIXOP1)
 Blockly.TypedLang.ORDER_RELATIONAL = 9;       // < <= > >= = <> (INFIXOP0)


### PR DESCRIPTION
今まで 5 - (3 - 1) が 5 - 3 - 1 と出力されてしまっていたのを直した。generator/javascript.js で ORDER_ADDITION と ORDER_SUBTRACTION が分かれていた理由がこれまで理解できていなかったが、
- 5 + (3 + 1) は 5 + 3 + 1 にしてよいが
- 5 - (3 - 1) は 5 - 3 - 1 にしてはだめ

なため、区別する必要があるためだったと理解しました。