### PR TITLE
abs ブロックを追加

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -287,6 +287,31 @@ Blockly.Blocks['int_arithmetic_typed'] = {
   }
 };
 
+Blockly.Blocks['int_abs_typed'] = {
+  /**
+   * Block for Pervasives.abs function.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.setColour(230);
+    this.setOutput(true, 'Int');
+    this.setOutputTypeExpr(new Blockly.TypeExpr.INT());
+    this.appendValueInput('A')
+        .setTypeExpr(new Blockly.TypeExpr.INT())
+        .appendField('abs');
+    this.setInputsInline(true);
+    this.setTooltip('整数の絶対値を計算する関数');
+  },
+
+  infer: function(ctx) {
+    var expected = new Blockly.TypeExpr.INT();
+    var arg = this.callInfer('A', ctx);
+    if (arg)
+      arg.unify(expected);
+    return expected;
+  }
+};
+
 Blockly.Blocks['float_typed'] = {
   /**
    * Block for numeric value.

--- a/demos/typed/dev.html
+++ b/demos/typed/dev.html
@@ -41,6 +41,7 @@
       <block type="int_typed"></block>
       <block type="int_arithmetic_typed"></block>
       <block type="max_int_typed"></block>
+      <block type="int_abs_typed"></block>
       <block type="float_typed"></block>
       <block type="float_arithmetic_typed"></block>
       <block type="infinity_typed"></block>

--- a/generators/typedlang/blocks.js
+++ b/generators/typedlang/blocks.js
@@ -98,6 +98,14 @@ Blockly.TypedLang['int_arithmetic_typed'] = function(block) {
   return [code, order];
 };
 
+Blockly.TypedLang['int_abs_typed'] = function(block) {
+  // int function "abs".
+  var argument = Blockly.TypedLang.valueToCode(block, 'A',
+      Blockly.TypedLang.ORDER_FUNCTION_CALL) || '?';
+  var code = 'abs ' + argument;
+  return [code, Blockly.TypedLang.ORDER_FUNCTION_CALL];
+};
+
 Blockly.TypedLang['float_typed'] = function(block) {
   // float value.
   var code = block.getFieldValue('Float');


### PR DESCRIPTION
<img width="911" alt="スクリーンショット 2019-04-04 21 57 25" src="https://user-images.githubusercontent.com/32429539/55557387-b21a0680-5724-11e9-8b03-26af3f90d090.png">

`Pervasives.abs : int -> int` のブロックを追加しました。
二項演算子のようにいくつかの関数から選べるようなブロックにしようかと思ったのですが、他に `int -> int` の関数が無かったので単純に `abs` ブロックです。
`not` ブロックに倣いました。