### PR TITLE
remove cons rule from Blockly.TypedLang.ORDER_OVERRIDES

### DIFF
--- a/generators/typedlang.js
+++ b/generators/typedlang.js
@@ -89,9 +89,7 @@ Blockly.TypedLang.ORDER_OVERRIDES = [
   // a || (b || c) -> a || b || c
   [Blockly.TypedLang.ORDER_LOGICAL_OR, Blockly.TypedLang.ORDER_LOGICAL_OR],
   // a ^ (b ^ c) -> a ^ b ^ c
-  [Blockly.TypedLang.ORDER_CONCAT_STRING, Blockly.TypedLang.ORDER_CONCAT_STRING],
-  // a :: (b :: c) -> a :: b :: c
-  [Blockly.TypedLang.ORDER_CONS, Blockly.TypedLang.ORDER_CONS]
+  [Blockly.TypedLang.ORDER_CONCAT_STRING, Blockly.TypedLang.ORDER_CONCAT_STRING]
 ];
 
 /**


### PR DESCRIPTION
Blockly.TypedLang.ORDER_OVERRIDES から cons の規則を削除。これがあると a :: (b :: c) のかっこだけでなく (a :: b) :: c のかっこも削除されてしまうため。