### PR TITLE
catch type error in connection.js to partly cope with issue #10

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -267,7 +267,13 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
 
   if (this.typeExprEnabled()) {
     var rootBlock = parentBlock.getRootBlock();
-    rootBlock.updateTypeInference();
+    try {
+      rootBlock.updateTypeInference();
+    } catch (e) {
+      var sourceBlock = this.getSourceBlock();
+      var mainWorkspace = sourceBlock.workspace.getMainWorkspace();
+      mainWorkspace.undo(false);
+    }
   }
 
   if (event) {


### PR DESCRIPTION
issue #10 への暫定対応として、型エラーを起こす部分を try catch で囲み、型エラーを起こした場合は undo することにしました。これで、明日の授業は乗り切ります。が、以下の問題がわかっています。
- 以下のプログラムで、`x` を `f` の body 部分に入れると（落ちることはなくなりましたが）接続を拒否された `x` のブロックがメインワークスペースに残ってしまいます。
```
let f x = ?
let test = f 0 = true
```
- 上のプログラムで、`x` のブロックを直接、使うのではなく、スコープお砂場を開き、そこから `f` の body 部分に入れると落ちているようです。

完璧な commit ではないですが、将来、undo がきちんとサポートされた暁には、まあ、使えるコードになりそうなので、pull request しておきます。undo した後、型推論をし直していませんが、する必要があったら加えてください。