### PR TITLE
include ja.js to display Japanese texts

### DIFF
--- a/blocks/typed_blocks.js
+++ b/blocks/typed_blocks.js
@@ -1469,9 +1469,9 @@ Blockly.Blocks['let_typed'] = {
     // returns non empty array.
     var option = {enabled: canBeToggled};
     if (this.isRecursive_) {
-      option.text = 'Remove rec.';
+      option.text = Blockly.Msg['REMOVE_REC'];
     } else {
-      option.text = 'Set rec.';
+      option.text = Blockly.Msg['ADD_REC'];
     }
     option.callback = this.setRecursiveFlag.bind(this, !this.isRecursive_);
     options.push(option);

--- a/demos/typed/typed.js
+++ b/demos/typed/typed.js
@@ -16,6 +16,7 @@ Typed.SCRIPTS_FOR_DEV = [
   "../../generators/typedlang.js",
   "../../generators/typedlang/blocks.js",
   "../../msg/js/en.js",
+  "../../msg/js/ja.js",
   "../../block_of_ocaml/converter.js",
   "../../block_of_ocaml/utils.js",
 ];
@@ -25,6 +26,7 @@ Typed.SCRIPTS_FOR_PROD = [
   "blocks_compressed.js",
   "typedlang_compressed.js",
   "en.js",
+  "ja.js",
   "converter.js",
   "block_of_ocaml_utils.js",
 ];

--- a/msg/json/ja.json
+++ b/msg/json/ja.json
@@ -20,6 +20,8 @@
 	"DUPLICATE_BLOCK": "複製",
 	"ADD_COMMENT": "コメントを追加",
 	"REMOVE_COMMENT": "コメントを削除",
+	"ADD_REC": "rec を追加",
+	"REMOVE_REC": "rec を削除",
 	"EXTERNAL_INPUTS": "外部入力",
 	"INLINE_INPUTS": "インライン入力",
 	"DELETE_BLOCK": "ブロックを削除",

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -1209,3 +1209,8 @@ Blockly.Msg.PROCEDURES_IFRETURN_WARNING = 'Warning: This block may be used only 
 /// comment text - This text appears in a new workspace comment, to hint that
 /// the user can type here.
 Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = 'Say something...';
+
+/// context menu - Add 'rec' to a let block
+Blockly.Msg.ADD_REC = 'Add rec';
+/// context menu - Remove 'rec' from a let block
+Blockly.Msg.REMOVE_REC = 'Remove rec';

--- a/update_docs.py
+++ b/update_docs.py
@@ -11,6 +11,7 @@ sourceMap = {
   "blocks_compressed.js": "./",
   "typedlang_compressed.js": "./",
   "en.js": "msg/js/",
+  "ja.js": "msg/js/",
   "index.html": "demos/typed/dev.html",
   "style.css": "demos/typed/",
   "typed.js": "demos/typed/",


### PR DESCRIPTION
メッセージ日本語化に向けて、とりあえずメニューに日本語が出るようにしました。この先、これを土台に、文字列を多国語対応していく予定です。本当は、web page 上にメニューが出てきて言語を選べるようになるとテストしやすいんだけど、その方法はまだ不明。今は en.js と ja.js の両方を入れているけど（ぼくの環境が日本語だから？）日本語が出てくる。

先日、メールした dev モードなら日本語が出るけど、圧縮すると出なかった件は、update_docs.py を更新したら出るようになりました。