### PR TITLE
change pattern variable names in record to fieldname_v

### DIFF
--- a/blocks/datatypes.js
+++ b/blocks/datatypes.js
@@ -885,23 +885,24 @@ Blockly.Blocks['record_pattern_typed'] = {
     if (index != 0) {
       input.appendField(';');
     }
+    var name = fieldValue.getVariableName();
     var field = Blockly.FieldBoundVariable.newReferenceRecordField(null,
-        fieldValue.getVariableName());
+        name);
     field.setBoundValue(fieldValue);
     input.appendField(field, 'FIELD' + index)
     input.appendField('=');
 
-    this.appendFieldText_(index, input);
+    this.appendFieldText_(index, input, name);
 
     field.initModel();
     this.fieldCount_++;
     return input;
   },
 
-  appendFieldText_: function(index, input) {
+  appendFieldText_: function(index, input, name) {
     var validator = Blockly.BoundVariables.variableNameValidator.bind(null,
         Blockly.BoundVariableAbstract.VARIABLE);
-    var field = new Blockly.FieldTextInput('a', validator);
+    var field = new Blockly.FieldTextInput(name + '_v', validator);
     input.appendField(field, 'TEXT' + index);
   },
 
@@ -938,9 +939,9 @@ Blockly.Blocks['record_pattern_value_typed'] = {
 
   appendFieldInput: Blockly.Blocks['record_pattern_typed'].appendFieldInput,
 
-  appendFieldText_: function(index, input) {
+  appendFieldText_: function(index, input, name) {
     var A = Blockly.TypeExpr.generateTypeVar();
-    var field = Blockly.FieldBoundVariable.newValue(A, 'a');
+    var field = Blockly.FieldBoundVariable.newValue(A, name + '_v');
     input.appendField(field, 'TEXT' + index);
     // Call initModel on the field after it's attached to a block. Otherwise
     // variable can not store information about where it's located. (e.g.,

--- a/core/bound_variables.js
+++ b/core/bound_variables.js
@@ -507,9 +507,8 @@ Blockly.BoundVariables.generateUniqueName = function(label, workspace) {
   }
 
   var isCtr = Blockly.BoundVariableAbstract.isConstructorLabel(label);
+  var isRecordName = Blockly.BoundVariableAbstract.isRecordLabel(label);
   var name = null;
-  var acode = 'a'.charCodeAt(0);
-  var zcode = 'z';
   var n = 0;
   while (!name) {
     var code = 'a'.charCodeAt(0);
@@ -520,6 +519,7 @@ Blockly.BoundVariables.generateUniqueName = function(label, workspace) {
       if (0 < n) {
         name += n;
       }
+      name = isRecordName ? name + '_t' : name;
       if (!Blockly.BoundVariables.isLegalName(label, name) ||
           name in namesMap) {
         name = null;


### PR DESCRIPTION
レコードのパターンに出て来るパターン変数の名前を `フィールド名_v` にしました。（これで issue #21 の問題のうち同じフィールド名が使われてしまう問題だけは回避できます。ただ、ほかのパターン変数と重なる名前に変更できてしまう問題は残っていますが。）